### PR TITLE
Add Docker instructions to README files for easier setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.env
+.venv
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+# System dependencies
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy requirements
+COPY pyproject.toml ./
+COPY uv.lock ./
+RUN pip install --upgrade pip
+RUN pip install uv
+RUN uv pip install --system .
+
+# Copy the rest of the code
+COPY . .
+
+EXPOSE 5006
+
+CMD ["uv", "run", "panel", "serve", "src/dashboard.py", "--autoreload", "--address", "0.0.0.0"]

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -88,3 +88,17 @@ Licença MIT - veja o arquivo [LICENSE](LICENSE) para detalhes.
 
 - Simulação Monte Carlo adaptada de [rueedlinger/monte-carlo-simulation](https://github.com/rueedlinger/monte-carlo-simulation)
 - Inspirado no livro [Actionable Agile Metrics for Predictability: An Introduction](https://actionableagile.com/books/aamfp/) de Daniel Vacanti
+
+## Rodar com Docker (sem Python local)
+
+Se você tem Docker instalado, pode construir e rodar o Kwando sem instalar Python ou dependências:
+
+```sh
+# Construa a imagem Docker (no diretório raiz do repositório)
+docker build -t kwando-dashboard .
+
+# Rode o dashboard, expondo em http://localhost:5006
+docker run -p 5006:5006 kwando-dashboard
+```
+
+Depois, acesse [http://localhost:5006](http://localhost:5006) no seu navegador.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,17 @@ MIT License - see the [LICENSE](LICENSE) file for details.
 
 - Monte Carlo simulation adapted from [rueedlinger/monte-carlo-simulation](https://github.com/rueedlinger/monte-carlo-simulation)
 - Inspired by the book [Actionable Agile Metrics for Predictability: An Introduction](https://actionableagile.com/books/aamfp/) by Daniel Vacanti
+
+## Run with Docker (no local Python required)
+
+If you have Docker installed, you can build and run Kwando without installing Python or any dependencies:
+
+```sh
+# Build the Docker image (run this in the root of the repo)
+docker build -t kwando-dashboard .
+
+# Run the dashboard, exposing it on http://localhost:5006
+docker run -p 5006:5006 kwando-dashboard
+```
+
+Then open [http://localhost:5006](http://localhost:5006) in your browser.


### PR DESCRIPTION
- Included a new section in both English and Portuguese README files detailing how to run the Kwando dashboard using Docker without requiring local Python installation.
- Provided step-by-step commands for building and running the Docker image, along with a link to access the dashboard in a browser.